### PR TITLE
allow write tlv instance + bug fix

### DIFF
--- a/core/management.c
+++ b/core/management.c
@@ -124,7 +124,7 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
         break;
     case COAP_PUT:
         {
-            if (LWM2M_URI_IS_SET_INSTANCE(uriP) && LWM2M_URI_IS_SET_RESOURCE(uriP))
+            if (LWM2M_URI_IS_SET_INSTANCE(uriP))
             {
                 result = object_write(contextP, uriP, message->payload, message->payload_len);
             }

--- a/core/objects.c
+++ b/core/objects.c
@@ -238,7 +238,7 @@ coap_status_t object_write(lwm2m_context_t * contextP,
             else
             {
                 size = lwm2m_tlv_parse(buffer, length, &tlvP);
-                if (size = 0) return COAP_500_INTERNAL_SERVER_ERROR;
+                if (size == 0) return COAP_500_INTERNAL_SERVER_ERROR;
             }
             result = targetP->writeFunc(uriP->instanceId, size, tlvP, targetP);
             lwm2m_tlv_free(size, tlvP);


### PR DESCRIPTION
It seems `objects.c` support to write an instance. So I edit management.c to allow this.
(+ a little bug fix on `objects.c`)
