### PR TITLE
bootstrap, first step implementation

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -12,5 +12,6 @@ SET(CORE_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/registration.c
     ${CMAKE_CURRENT_LIST_DIR}/management.c
     ${CMAKE_CURRENT_LIST_DIR}/observe.c
+    ${CMAKE_CURRENT_LIST_DIR}/bootstrap.c
     ${EXT_SOURCES}
     PARENT_SCOPE)

--- a/core/bootstrap.c
+++ b/core/bootstrap.c
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ *
+ * Copyright (c) 2013, 2014 Intel Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * The Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Julien Vermillard, Sierra Wireless
+ *
+ *******************************************************************************/
+
+#include "internals.h"
+
+#define QUERY_TEMPLATE "bs="
+#define QUERY_LENGTH 3
+
+#ifdef LWM2M_CLIENT_MODE
+
+int lwm2m_bootstrap(lwm2m_context_t * contextP)
+{
+    char * query;
+    coap_packet_t message[1];
+    uint8_t pktBuffer[COAP_MAX_PACKET_SIZE+1];
+    size_t pktBufferLen = 0;
+
+    if (contextP->bootstrapServer == NULL) return COAP_500_INTERNAL_SERVER_ERROR;
+
+    query = (char*) lwm2m_malloc(QUERY_LENGTH + strlen(contextP->endpointName) + 1);
+    if (query == NULL) return COAP_500_INTERNAL_SERVER_ERROR;
+    strcpy(query, QUERY_TEMPLATE);
+    strcpy(query + QUERY_LENGTH, contextP->endpointName);
+
+    // can't use a transaction, becasue transaction needs a server struct
+    coap_init_message(message, COAP_TYPE_CON, COAP_POST, contextP->nextMID++);
+    coap_set_header_uri_path(message, "/"URI_BOOTSTRAP_SEGMENT);
+    coap_set_header_uri_query(message, query);
+
+    pktBufferLen = coap_serialize_message(message, pktBuffer);
+    if (0 != pktBufferLen)
+    {
+        contextP->bufferSendCallback(contextP->bootstrapServer->sessionH, pktBuffer, pktBufferLen, contextP->bufferSendUserData);
+        return 0;
+    } else {
+        return INTERNAL_SERVER_ERROR_5_00;
+    }
+    lwm2m_free(query);
+}
+
+#endif

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -210,7 +210,7 @@ void lwm2m_close(lwm2m_context_t * contextP)
 
 #ifdef LWM2M_CLIENT_MODE
 void lwm2m_set_bootstrap_server(lwm2m_context_t * contextP,
-                               lwm2m_bootstrap_server_t * serverP)
+                              char* uri, void* sessionH)
 {
     if (NULL != contextP->bootstrapServer)
     {
@@ -219,6 +219,16 @@ void lwm2m_set_bootstrap_server(lwm2m_context_t * contextP,
         if (NULL != contextP->bootstrapServer->security.publicKey) lwm2m_free (contextP->bootstrapServer->security.publicKey);
         lwm2m_free(contextP->bootstrapServer);
     }
+
+    lwm2m_bootstrap_server_t * serverP = lwm2m_malloc(sizeof(lwm2m_bootstrap_server_t ));
+    if (serverP == NULL) return;
+
+    serverP->uri = lwm2m_malloc(strlen(uri) + 1);
+    if (serverP->uri == NULL) return;
+
+    strcpy(serverP->uri, uri);
+
+    serverP->sessionH = sessionH;
     contextP->bootstrapServer = serverP;
 }
 

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -317,6 +317,7 @@ typedef struct
     char *           uri;
     lwm2m_security_t security;
     uint32_t         holdOffTime;
+    void *           sessionH;
 } lwm2m_bootstrap_server_t;
 
 /*
@@ -473,7 +474,7 @@ int lwm2m_step(lwm2m_context_t * contextP, struct timeval * timeoutP);
 void lwm2m_handle_packet(lwm2m_context_t * contextP, uint8_t * buffer, int length, void * fromSessionH);
 
 #ifdef LWM2M_CLIENT_MODE
-void lwm2m_set_bootstrap_server(lwm2m_context_t * contextP, lwm2m_bootstrap_server_t * serverP);
+void lwm2m_set_bootstrap_server(lwm2m_context_t * contextP, char * uri, void * sessionH);
 int lwm2m_add_server(lwm2m_context_t * contextP, uint16_t shortID, uint32_t lifetime, char * sms, lwm2m_binding_t binding, void * sessionH, lwm2m_security_t * securityP);
 
 // send registration message to all known LWM2M Servers.
@@ -484,6 +485,9 @@ int lwm2m_update_registration(lwm2m_context_t * contextP, uint16_t shortServerID
 
 // inform liblwm2m that a resource value has changed.
 void lwm2m_resource_value_changed(lwm2m_context_t * contextP, lwm2m_uri_t * uriP);
+
+// contact the bootstrap server (if any)
+int lwm2m_bootstrap(lwm2m_context_t * contextP);
 #endif
 
 #ifdef LWM2M_SERVER_MODE


### PR DESCRIPTION
You can add a bootstrap server, and trigger a bootstrap.
A 'bootstrap' command is added to the client.

Bootstrap doesn't use a transaction because currently transaction.c
works only with lwm2m_server now.
Bootstrap won't work now because the bootstrap server will try to DELETE
the whole /1/ hierarchy and provision new servers which is cleary not
supported.

Next step for me is to implement bootstrap in Leshan for having a clear understanding of the whole process. Then I'll be back tackling the remaining issues.
