### PR TITLE
TLV opaqueToInt error

### DIFF
--- a/core/tlv.c
+++ b/core/tlv.c
@@ -277,7 +277,7 @@ int lwm2m_opaqueToInt(char * buffer,
 
     for (i = 1 ; i < buffer_len ; i++)
     {
-        *dataP = (*dataP << 8) + buffer[i];
+        *dataP = (*dataP << 8) + (buffer[i]&0xFF);
     }
 
     // first bit is the sign


### PR DESCRIPTION
Sign extension causes some conversion error in TLV decoding.

To reproduce the error you may run the /test/TLV/ example. In the second decode I get wrong value "as int" for resource instances 7/0, 7/1, 8/0  and 8/1; the int value is totally differente from the hex printed in the line before.
