### PR TITLE
Not need to call deregister when the status is STATE_REG_PENDING.

### DIFF
--- a/core/registration.c
+++ b/core/registration.c
@@ -348,6 +348,7 @@ void registration_deregister(lwm2m_context_t * contextP,
     size_t pktBufferLen = 0;
 
     if (serverP->status == STATE_UNKNOWN
+     || serverP->status == STATE_REG_PENDING
      || serverP->status == STATE_DEREG_PENDING)
         {
             return;


### PR DESCRIPTION
Calling _lwm2m_close()_ will crash when the status of the server is **STATE_REG_PENDING**. Because there is not location when the server at **STATE_REG_PENDING**.
I think it is not need to call deregister when we don't know if the client can register or not.
