### PR TITLE
ci: Automatically label and close stale issues

### DIFF
--- a/.github/workflows/close-stale-issues.yaml
+++ b/.github/workflows/close-stale-issues.yaml
@@ -1,0 +1,23 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 2 1 * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-22.04
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 365
+          days-before-issue-close: 365
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for a year with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for a year since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          debug-only: true  # remove this to activate this GH action


### PR DESCRIPTION
This helps to keep the list of issues short and relevant.

Should we do some automatic clean-up tasks?

If yes: Should we also automatically close old PRs?

TODO: remove `debug-only`