### PR TITLE
Fix payload fragmentation in client SEND operation #770

### DIFF
--- a/core/observe.c
+++ b/core/observe.c
@@ -943,7 +943,10 @@ int lwm2m_send(lwm2m_context_t *contextP, uint16_t shortServerID, lwm2m_uri_t *u
 
         coap_set_header_uri_path(transactionP->message, "/" URI_SEND_SEGMENT);
         coap_set_header_content_type(transactionP->message, format);
-        coap_set_payload(transactionP->message, buffer, length);
+        if (!transaction_set_payload(transactionP, buffer, length)) {
+            transaction_free(transactionP);
+            return COAP_500_INTERNAL_SERVER_ERROR;
+        }
 
         transactionP->callback = callback;
         transactionP->userData = userData;


### PR DESCRIPTION
In this PR, I replaced the _coap_set_payload_ function with _transaction_set_payload_. As a result, the client can now send large data in separate CoAP packets instead of a single large packet that was previously rejected by the server