### PR TITLE
ci: Add build and test on macOS

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -1,0 +1,30 @@
+name: Build and Test on macOS
+
+on:
+  push:
+    branches: '**'
+  pull_request:
+    branches: '**'
+
+jobs:
+  build_and_test:
+    runs-on: macos-14
+
+    steps:
+    - name: Checkout code including full history and submodules
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+        fetch-depth: 0
+
+    - name: Install dependencies from Homebrew
+      run: |
+        brew install automake cmake cunit gnu-getopt make ninja
+
+    - name: Build all binaries
+      run: |
+        tools/ci/run_ci.sh --run-build  --verbose
+
+    - name: Build, execute unit tests
+      run: |
+        tools/ci/run_ci.sh --run-tests

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ On Ubuntu 20.04, used in CI, the dependencies can be installed as such:
 
 For macOS the development dependencies can be installed as such:
 
-`brew install automake clang-format cmake cunit gcc gitlint make ninja`
+`brew install automake clang-format cmake cunit gcc gitlint gnu-getopt make ninja`
 
 ### Code formatting
 #### C

--- a/tools/ci/run_ci.sh
+++ b/tools/ci/run_ci.sh
@@ -198,14 +198,20 @@ function run_tests() {
 
 # Parse Options
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  getopt=$(brew --prefix gnu-getopt)/bin/getopt
+else
+  getopt=$(which getopt)
+fi
+
 ret=0
-getopt --test > /dev/null || ret=$?
+$getopt --test > /dev/null || ret=$?
 if [ $ret -ne 4 ]; then
   echo "Error: getopt version is not as expected"
   exit 1
 fi
 
-if ! PARSED_OPTS=$(getopt -o vah \
+if ! PARSED_OPTS=$($getopt -o vah \
                           -l all \
                           -l branch-source: \
                           -l branch-target: \


### PR DESCRIPTION
Building and testing Wakaama on macOS with the default compiler and no additional sanitizers. This makes sure that the code can be used with macOS.