### PR TITLE
Fix LWM2M_RAW_BLOCK1_REQUESTS compile

### DIFF
--- a/core/internals.h
+++ b/core/internals.h
@@ -480,7 +480,9 @@ int discover_serialize(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_ser
 
 // defined in block.c
 #ifdef LWM2M_RAW_BLOCK1_REQUESTS
-uint8_t coap_block1_handler(lwm2m_block_data_t ** blockData, const char * uri, uint16_t mid, uint8_t * buffer, size_t length, uint16_t blockSize, uint32_t blockNum, bool blockMore, uint8_t ** outputBuffer, size_t * outputLength);
+uint8_t coap_block1_handler(lwm2m_block_data_t **blockData, const char *uri, uint16_t mid, const uint8_t *buffer,
+                            size_t length, uint16_t blockSize, uint32_t blockNum, bool blockMore,
+                            uint8_t **outputBuffer, size_t *outputLength);
 #else
 uint8_t coap_block1_handler(lwm2m_block_data_t **blockData, const char *uri, const uint8_t *buffer, size_t length,
                             uint16_t blockSize, uint32_t blockNum, bool blockMore, uint8_t **outputBuffer,

--- a/core/objects.c
+++ b/core/objects.c
@@ -526,9 +526,7 @@ uint8_t object_raw_block1_write(lwm2m_context_t * contextP,
                             uint8_t block_more)
 {
     uint8_t result = NO_ERROR;
-    lwm2m_object_t * targetP;
-    lwm2m_data_t * dataP = NULL;
-    int size = 0;
+    lwm2m_object_t *targetP;
 
     LOG_URI(uriP);
     targetP = (lwm2m_object_t *)LWM2M_LIST_FIND(contextP->objectList, uriP->objectId);

--- a/examples/client/CMakeLists.txt
+++ b/examples/client/CMakeLists.txt
@@ -25,6 +25,14 @@ target_compile_definitions(lwm2mclient PRIVATE LWM2M_CLIENT_MODE LWM2M_BOOTSTRAP
 target_sources_wakaama(lwm2mclient)
 target_sources_shared(lwm2mclient)
 
+# Client without raw block 1 requests DTLS support
+add_executable(lwm2mclient_raw_block1 ${SOURCES})
+target_compile_definitions(
+    lwm2mclient_raw_block1 PRIVATE LWM2M_CLIENT_MODE LWM2M_BOOTSTRAP LWM2M_SUPPORT_SENML_JSON LWM2M_RAW_BLOCK1_REQUESTS
+)
+target_sources_wakaama(lwm2mclient_raw_block1)
+target_sources_shared(lwm2mclient_raw_block1)
+
 # Client with DTLS support provided by tinydtls
 add_executable(lwm2mclient_tinydtls ${SOURCES})
 set_target_properties(lwm2mclient_tinydtls PROPERTIES CONNECTION_IMPLEMENTATION "tinydtls")

--- a/examples/client/object_firmware.c
+++ b/examples/client/object_firmware.c
@@ -299,6 +299,20 @@ static uint8_t prv_firmware_execute(lwm2m_context_t *contextP,
     }
 }
 
+#ifdef LWM2M_RAW_BLOCK1_REQUESTS
+static uint8_t prv_firmware_raw_block1_write(lwm2m_context_t *contextP, lwm2m_uri_t *uriP, lwm2m_media_type_t format,
+                                             uint8_t *buffer, int length, lwm2m_object_t *objectP, uint32_t block_num,
+                                             uint8_t block_more) {
+    // a full implementation would store data to flash and update the
+    // firmware upload state machine and result here.
+    if (block_more == 0) {
+        return COAP_204_CHANGED;
+    }
+
+    return COAP_231_CONTINUE;
+}
+#endif
+
 void display_firmware_object(lwm2m_object_t * object)
 {
     firmware_data_t * data = (firmware_data_t *)object->userData;
@@ -352,6 +366,9 @@ lwm2m_object_t * get_object_firmware(void)
         firmwareObj->readFunc    = prv_firmware_read;
         firmwareObj->writeFunc   = prv_firmware_write;
         firmwareObj->executeFunc = prv_firmware_execute;
+#ifdef LWM2M_RAW_BLOCK1_REQUESTS
+        firmwareObj->rawBlock1WriteFunc = prv_firmware_raw_block1_write;
+#endif
         firmwareObj->userData    = lwm2m_malloc(sizeof(firmware_data_t));
 
         /*

--- a/examples/client/object_test.c
+++ b/examples/client/object_test.c
@@ -355,14 +355,11 @@ static uint8_t prv_raw_block1_write(lwm2m_context_t *contextP,
     {
         prv_block_buffer_free(targetP);
 
-        int offset; // length of id field  
-        
-        if (payload[0] & 0x20 == 0x20)
-        {
+        int offset; // length of id field
+
+        if ((payload[0] & 0x20) == 0x20) {
             offset = 2;
-        }
-        else
-        {
+        } else {
             offset = 1;
         }
         switch (payload[0] & 0x18)
@@ -386,6 +383,9 @@ static uint8_t prv_raw_block1_write(lwm2m_context_t *contextP,
                 targetP->value_len = (payload[offset]<<16) + (payload[offset+1]<<8) + payload[offset+2];
                 offset += 3;
                 break;
+            default:
+                // this should never occur, so return Bad Request
+                return COAP_400_BAD_REQUEST;
         }
         targetP->value_offset = offset;
         targetP->block_buffer = lwm2m_malloc(targetP->value_offset + targetP->value_offset);


### PR DESCRIPTION
Addresses the compile issues referenced in #773 when using the `LWM2M_RAW_BLOCK1_REQUESTS` compile flag by:
- removing unused variables
- specifying the missing const keyword.

In addition, to help validate that this doesn't happen in the future, this commit adds an additional configuration option to the client example which enables the `LWM2M_RAW_BLOCK1_REQUESTS` option. This allows for a basic test that compilation succeeds. It does not go further in attempting to add unit tests for this compile option.