### PR TITLE
ci: Fix Sonar organization and project name

### DIFF
--- a/.github/workflows/sonarcloud-scan.yaml
+++ b/.github/workflows/sonarcloud-scan.yaml
@@ -39,8 +39,8 @@ jobs:
         -Dsonar.exclusions="build-wakaama-*/**, .git/**" \
         -Dsonar.host.url=https://sonarcloud.io \
         -Dsonar.login=${{ secrets.SONAR_TOKEN }} \
-        -Dsonar.organization=${{ github.repository_owner }} \
-        -Dsonar.projectKey="$(echo ${{ github.repository }} | tr / _)" \
+        -Dsonar.organization="eclipse" \
+        -Dsonar.projectKey="eclipse_wakaama" \
         -Dsonar.sourceEncoding=UTF-8 \
         -Dsonar.sources=.
       env:


### PR DESCRIPTION
Wakaama moved to the GitHub organization `eclipse-wakaama` but the organization and project names in Sonar Cloud have not changed.