### PR TITLE
cmake: Allow client related settings from CMake

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -51,6 +51,10 @@
           "type": "BOOL",
           "value": "ON"
         },
+        "WAKAAMA_CLIENT_INITIATED_BOOTSTRAP": {
+          "type": "BOOL",
+          "value": "ON"
+        },
         "WAKAAMA_ENABLE_EXAMPLES": {
           "type": "BOOL",
           "value": "ON"

--- a/README.md
+++ b/README.md
@@ -85,9 +85,6 @@ Several preprocessor definitions are supported:
  - LWM2M_SUPPORT_SENML_JSON to enable SenML JSON payload support (implicit for LWM2M 1.1 or greater when defining LWM2M_SERVER_MODE or LWM2M_BOOTSTRAP_SERVER_MODE)
  - LWM2M_SUPPORT_SENML_CBOR to enable SenML CBOR payload support (implicit for LWM2M 1.1 or greater when defining LWM2M_SERVER_MODE or LWM2M_BOOTSTRAP_SERVER_MODE)
  - LWM2M_OLD_CONTENT_FORMAT_SUPPORT to support the deprecated content format values for TLV and JSON.
- - Version 1.1 of LWM2M is supported per default, but can be constrained to older versions:
-   - LWM2M_VERSION_1_0 to support only version 1.0
-   Please note: Clients support only the specified version, while servers are backward compatible.
  - LWM2M_RAW_BLOCK1_REQUESTS For low memory client devices where it is not possible to keep a large post or put request in memory to be parsed (typically a firmware write).
    This option enable each unprocessed block 1 payload to be passed to the application, typically to be stored to a flash memory.
  - LWM2M_COAP_DEFAULT_BLOCK_SIZE CoAP block size used by CoAP layer when performing block-wise transfers. Possible values: 16, 32, 64, 128, 256, 512 and 1024. Defaults to 1024.
@@ -99,6 +96,15 @@ Wakaama supports multiple modes. At least one mode needs to be defined with CMak
 - WAKAAMA_MODE_SERVER to enable LWM2M Server interfaces.
 - WAKAAMA_MODE_BOOTSTRAP_SERVER to enable LWM2M Bootstrap Server interfaces.
 - WAKAAMA_MODE_CLIENT to enable LWM2M Client interfaces.
+
+#### Client Settings
+
+Wakaama supports additional client related options. These are only available if the client mode is enabled. 
+
+- WAKAAMA_CLIENT_INITIATED_BOOTSTRAP to enable LWM2M Bootstrap support in a LWM2M Client.
+- WAKAAMA_CLIENT_LWM2M_V_1_0: Restrict the client code to use LwM2M version 1.0
+ 
+Please note: LwM2M version 1.0 is only supported by clients, while servers are backward compatible.
 
 ### Logging
 

--- a/examples/client/CMakeLists.txt
+++ b/examples/client/CMakeLists.txt
@@ -4,7 +4,10 @@ project(lwm2mclient C)
 
 include(../../wakaama.cmake)
 
-if(WAKAAMA_ENABLE_EXAMPLES AND WAKAAMA_MODE_CLIENT)
+if(WAKAAMA_ENABLE_EXAMPLES
+   AND WAKAAMA_MODE_CLIENT
+   AND WAKAAMA_CLIENT_INITIATED_BOOTSTRAP
+)
 
     set(SOURCES
         lwm2mclient.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,15 +51,17 @@ add_test_variant(
     COMPILE_DEFINITIONS LWM2M_SERVER_MODE
 )
 
-add_test_variant(
-    TARGET_NAME lwm2munittests_client_server_bootstrap_all_formats
-    SOURCE_FILES ${TEST_SOURCES}
-    COMPILE_DEFINITIONS
-        LWM2M_CLIENT_MODE
-        LWM2M_SERVER_MODE
-        LWM2M_BOOTSTRAP_SERVER_MODE
-        LWM2M_SERVER_MODE
-        LWM2M_OLD_CONTENT_FORMAT_SUPPORT
-        LWM2M_SUPPORT_SENML_JSON
-        LWM2M_SUPPORT_SENML_CBOR
-)
+if(NOT WAKAAMA_CLIENT_INITIATED_BOOTSTRAP)
+    add_test_variant(
+        TARGET_NAME lwm2munittests_client_server_bootstrap_all_formats
+        SOURCE_FILES ${TEST_SOURCES}
+        COMPILE_DEFINITIONS
+            LWM2M_CLIENT_MODE
+            LWM2M_SERVER_MODE
+            LWM2M_BOOTSTRAP_SERVER_MODE
+            LWM2M_SERVER_MODE
+            LWM2M_OLD_CONTENT_FORMAT_SUPPORT
+            LWM2M_SUPPORT_SENML_JSON
+            LWM2M_SUPPORT_SENML_CBOR
+    )
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,7 @@ set(TEST_SOURCES
     helper/log_handler.c
 )
 
-if(LWM2M_CLIENT_MODE AND NOT WAKAAMA_MODE_BOOTSTRAP_SERVER)
+if(WAKAAMA_MODE_CLIENT AND NOT WAKAAMA_MODE_BOOTSTRAP_SERVER)
     add_test_variant(
         TARGET_NAME lwm2munittests_client_lwm2m_1_0
         SOURCE_FILES ${TEST_SOURCES}

--- a/wakaama.cmake
+++ b/wakaama.cmake
@@ -7,6 +7,10 @@ option(WAKAAMA_MODE_SERVER "Enable LWM2M Server interfaces" OFF)
 option(WAKAAMA_MODE_BOOTSTRAP_SERVER "Enable LWM2M Bootstrap Server interfaces" OFF)
 option(WAKAAMA_MODE_CLIENT "Enable LWM2M Client interfaces" OFF)
 
+# Client
+option(WAKAAMA_CLIENT_INITIATED_BOOTSTRAP "Enable client initiated bootstrap support in a client" OFF)
+option(WAKAAMA_CLIENT_LWM2M_V_1_0 "Restrict the client code to use LwM2M version 1.0" OFF)
+
 # Logging
 set(WAKAAMA_LOG_LEVEL
     LOG_DISABLED
@@ -47,6 +51,17 @@ function(set_mode_defines target)
     endif()
 endfunction()
 
+# Set the defines for client specific configuration
+function(set_client_defines target)
+    if(WAKAAMA_CLIENT_INITIATED_BOOTSTRAP)
+        target_compile_definitions(${target} PUBLIC LWM2M_BOOTSTRAP)
+    endif()
+
+    if(WAKAAMA_CLIENT_LWM2M_V_1_0)
+        target_compile_definitions(${target} PUBLIC LWM2M_VERSION_1_0)
+    endif()
+endfunction()
+
 # Set the defines for logging configuration
 function(set_logging_defines target)
     # Logging
@@ -62,6 +77,7 @@ endfunction()
 # Set all the requested defines on target
 function(set_defines target)
     set_mode_defines(${target})
+    set_client_defines(${target})
     set_logging_defines(${target})
 endfunction()
 


### PR DESCRIPTION
The settings for "Client Initiated Bootstrap" and restriction to LwM2M version 1.0 can be now set with CMake options.
These options are only available if the client mode is enabled.