### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,34 +26,6 @@ This work is dual-licensed under the Eclipse Public License v2.0 and Eclipse Dis
 
 [![Build](https://github.com/eclipse/wakaama/actions/workflows/build_and_test.yaml/badge.svg)](https://github.com/eclipse/wakaama/actions/workflows/build_and_test.yaml)
 
-## Source Layout
-
-    -+- core                   (the LWM2M engine)
-     |
-     +- coap                   (CoAP stack adaptation)
-     |    |
-     |    +- er-coap-13        (Modified Erbium's CoAP engine from
-     |                          https://web.archive.org/web/20180316172739/http://people.inf.ethz.ch/mkovatsc/erbium.php)
-     |
-     +- data                   (data formats serialization/deserialization)
-     |
-     +- tests                  (test cases)
-     |    |
-     |    +- integration       (pytest based integration tests implementing the OMA-ETS-LightweightM2M-V1_1-20190912-D specification
-     |                          https://www.openmobilealliance.org/release/LightweightM2M/ETS/OMA-ETS-LightweightM2M-V1_1-20190912-D.pdf)
-     +- examples
-          |
-          +- bootstrap_server  (a command-line LWM2M bootstrap server)
-          |
-          +- client            (a command-line LWM2M client with several test objects)
-          |
-          +- lightclient       (a very simple command-line LWM2M client with several test objects)
-          |
-          +- server            (a command-line LWM2M server)
-          |
-          +- shared            (utility functions for connection handling and command-
-                                line interface)
-
 ## Checking out the code
 
 ### Using Wakaama as library

--- a/README.md
+++ b/README.md
@@ -144,10 +144,10 @@ There are some example applications provided to test the server, client and boot
 The following recipes assume you are on a unix like platform and you have cmake and make installed.
 
 ### Server example
- * Create a build directory and change to that.
- * ``cmake [wakaama directory]/examples/server``
- * ``make``
- * ``./lwm2mserver [Options]``
+
+ * ``cmake -S examples/server -B build-server -DWAKAAMA_MODE_SERVER=ON``
+ * ``cmake --build build-server``
+ * ``./build-server/lwm2mserver [Options]``
 
 The lwm2mserver listens on UDP port 5683. It features a basic command line
 interface. Type 'help' for a list of supported commands.
@@ -164,10 +164,10 @@ Options:
 ```
 
 ### Test client example
- * Create a build directory and change to that.
- * ``cmake [wakaama directory]/examples/client``
- * ``make``
- * ``./lwm2mclient [Options]``
+
+ * ``cmake -S examples/client -B build-client -DWAKAAMA_MODE_CLIENT=ON``
+ * ``cmake --build build-client``
+ * ``./build-client/lwm2mclient [Options]``
 
 Next to lwm2mclient a DTLS enabled variant named lwm2mclient_tinydtls gets built.
 
@@ -226,11 +226,9 @@ To launch a bootstrap session:
 
 ### Simpler test client example
 
-In the any directory, run the following commands:
- * Create a build directory and change to that.
- * ``cmake [wakaama directory]/examples/lightclient``
- * ``make``
- * ``./lightclient [Options]``
+ * ``cmake -S examples/lightclient -B build-lightclient``
+ * ``cmake --build build-lightclient``
+ * ``./build-lightclient/lightclient [Options]``
 
 The lightclient is much simpler that the lwm2mclient and features only four
 LWM2M objects:
@@ -253,9 +251,9 @@ Options:
   -S BYTES	CoAP block size. Options: 16, 32, 64, 128, 256, 512, 1024. Default: 1024
 ```
 ### Bootstrap Server example
- * Create a build directory and change to that.
- * ``cmake [wakaama directory]/examples/bootstrap_server``
- * ``make``
- * ``./bootstrap_server [Options]``
+
+ * ``cmake -S examples/bootstrap_server -B build-bootstrap -DWAKAAMA_MODE_BOOTSTRAP_SERVER=ON``
+ * ``cmake --build build-bootstrap``
+ * ``./build-bootstrap/bootstrap_server [Options]``
 
 Refer to [examples/bootstrap_server/README](./examples/bootstrap_server/README) for more information.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Wakaama
 
+[![Build](https://github.com/eclipse/wakaama/actions/workflows/build_and_test.yaml/badge.svg)](https://github.com/eclipse/wakaama/actions/workflows/build_and_test.yaml)
+
 Wakaama (formerly liblwm2m) is an implementation of the Open Mobile Alliance's LightWeight M2M
 protocol (LWM2M).
 
@@ -21,10 +23,6 @@ supported anymore.
 This work is dual-licensed under the Eclipse Public License v2.0 and Eclipse Distribution License v1.0.
 
 `SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause`
-
-## Badges
-
-[![Build](https://github.com/eclipse/wakaama/actions/workflows/build_and_test.yaml/badge.svg)](https://github.com/eclipse/wakaama/actions/workflows/build_and_test.yaml)
 
 ## Checking out the code
 


### PR DESCRIPTION
Rework the readme file a bit.

- **Remove layout section**
  This section provides limited use since Github as well as modern IDEs
  have good file browsing built in. The source layout section consumes
  valuable visual space on the Github landing page and distracts from
  other important information.
- **Move CI batch to the top**
  There is no need for a separate section for batches. This nicely fits
  below the project name.

- **Update cmake commands to build examples**
  Update build commands for examples with cmake variables to configure the
  build process.