### PR TITLE
cmake: Allow CoAP related setting from CMake

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,6 @@ Several preprocessor definitions are supported:
  - LWM2M_SUPPORT_SENML_JSON to enable SenML JSON payload support (implicit for LWM2M 1.1 or greater when defining LWM2M_SERVER_MODE or LWM2M_BOOTSTRAP_SERVER_MODE)
  - LWM2M_SUPPORT_SENML_CBOR to enable SenML CBOR payload support (implicit for LWM2M 1.1 or greater when defining LWM2M_SERVER_MODE or LWM2M_BOOTSTRAP_SERVER_MODE)
  - LWM2M_OLD_CONTENT_FORMAT_SUPPORT to support the deprecated content format values for TLV and JSON.
- - LWM2M_RAW_BLOCK1_REQUESTS For low memory client devices where it is not possible to keep a large post or put request in memory to be parsed (typically a firmware write).
-   This option enable each unprocessed block 1 payload to be passed to the application, typically to be stored to a flash memory.
- - LWM2M_COAP_DEFAULT_BLOCK_SIZE CoAP block size used by CoAP layer when performing block-wise transfers. Possible values: 16, 32, 64, 128, 256, 512 and 1024. Defaults to 1024.
 
 ### Mode
 
@@ -75,6 +72,13 @@ Wakaama supports additional client related options. These are only available if 
 - WAKAAMA_CLIENT_LWM2M_V_1_0: Restrict the client code to use LwM2M version 1.0
  
 Please note: LwM2M version 1.0 is only supported by clients, while servers are backward compatible.
+
+### CoAP Settings
+
+- WAKAAMA_COAP_RAW_BLOCK1_REQUESTS For low memory client devices where it is not possible to keep a large post or put request in memory to be parsed (typically a firmware write).
+  This option enable each unprocessed block 1 payload to be passed to the application, typically to be stored to a flash memory.
+- WAKAAMA_COAP_DEFAULT_BLOCK_SIZE CoAP block size used by CoAP layer when performing block-wise transfers. Possible values: 16, 32, 64, 128, 256, 512 and 1024. Defaults to 1024.
+
 
 ### Logging
 

--- a/wakaama.cmake
+++ b/wakaama.cmake
@@ -11,6 +11,26 @@ option(WAKAAMA_MODE_CLIENT "Enable LWM2M Client interfaces" OFF)
 option(WAKAAMA_CLIENT_INITIATED_BOOTSTRAP "Enable client initiated bootstrap support in a client" OFF)
 option(WAKAAMA_CLIENT_LWM2M_V_1_0 "Restrict the client code to use LwM2M version 1.0" OFF)
 
+# CoAP
+option(WAKAAMA_COAP_RAW_BLOCK1_REQUESTS "Pass each unprocessed block 1 payload to the application" OFF)
+
+set(WAKAAMA_COAP_DEFAULT_BLOCK_SIZE
+    1024
+    CACHE STRING "Default CoAP block size for block-wise transfers"
+)
+set_property(
+    CACHE WAKAAMA_COAP_DEFAULT_BLOCK_SIZE
+    PROPERTY STRINGS
+             LOG_DISABLED
+             16
+             32
+             64
+             128
+             256
+             512
+             1024
+)
+
 # Logging
 set(WAKAAMA_LOG_LEVEL
     LOG_DISABLED
@@ -62,6 +82,15 @@ function(set_client_defines target)
     endif()
 endfunction()
 
+# Set the defines related to CoAP
+function(set_coap_defines)
+    if(WAKAAMA_COAP_RAW_BLOCK1_REQUESTS)
+        target_compile_definitions(${target} PUBLIC LWM2M_RAW_BLOCK1_REQUESTS)
+    endif()
+
+    target_compile_definitions(${target} PUBLIC LWM2M_COAP_DEFAULT_BLOCK_SIZE=${WAKAAMA_COAP_DEFAULT_BLOCK_SIZE})
+endfunction()
+
 # Set the defines for logging configuration
 function(set_logging_defines target)
     # Logging
@@ -78,6 +107,7 @@ endfunction()
 function(set_defines target)
     set_mode_defines(${target})
     set_client_defines(${target})
+    set_coap_defines(${target})
     set_logging_defines(${target})
 endfunction()
 


### PR DESCRIPTION
The settings regarding raw block-wise transfer and default block size can now be set from CMake.