### PR TITLE
git-blame: Adjust git blame ignores

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,4 +3,4 @@
 # Cleaning up Eclipse headers
 019c299b7183d49f975384651f2cf37ec60930d7
 # Cleaning up unit test files 
-920c6cf29ada2fddb7bce3c80592e201fe538c60
+9581e3a524ad72e00a78a677c002faab37f5764c


### PR DESCRIPTION
`git-blame-ignore-revs` is broken because Github rewrote history during merge.

Error:
```
.git-blame-ignore-revs: Commit 920c6cf29ada2fddb7bce3c80592e201fe538c60 is not an ancestor.
```

This should fix the CI again.