### PR TITLE
send: Return not found if client is NULL

### DIFF
--- a/core/reporting.c
+++ b/core/reporting.c
@@ -36,7 +36,7 @@ uint8_t reporting_handleSend(lwm2m_context_t *contextP, void *fromSessionH, coap
             break;
     }
     if (clientP == NULL)
-        return COAP_400_BAD_REQUEST;
+        return COAP_404_NOT_FOUND;
 
     format = utils_convertMediaType(message->content_type);
 


### PR DESCRIPTION
Return 4.04 not found in case the provided client is not valid.