### PR TITLE
doc: Add autoconf as build dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,12 +108,12 @@ The logging infrastructure can be configured with CMake cache variables (e.g. `c
   - Unit testing: CUnit
 
 On Ubuntu 20.04, used in CI, the dependencies can be installed as such:
-- `apt install build-essential clang-format clang-format-14 clang-tools-14 cmake gcovr git libcunit1-dev ninja-build python3-pip`
+- `apt install autoconf build-essential clang-format clang-format-14 clang-tools-14 cmake gcovr git libcunit1-dev ninja-build python3-pip`
 - `pip3 install -r tools/requirements-compliance.txt`
 
 For macOS the development dependencies can be installed as such:
 
-`brew install automake clang-format cmake cunit gcc gitlint gnu-getopt make ninja`
+`brew install autoconf automake clang-format cmake cunit gcc gitlint gnu-getopt make ninja`
 
 ### Code formatting
 #### C


### PR DESCRIPTION
 `autoconf` is a dependency of the `tinydtls` library.
