### PR TITLE
Remove code duplication in client example

### DIFF
--- a/examples/client/object_connectivity_moni.c
+++ b/examples/client/object_connectivity_moni.c
@@ -86,6 +86,19 @@ typedef struct
     int linkUtilization;
 } conn_m_data_t;
 
+static void reduce_single_instance(lwm2m_data_t *const dataP, lwm2m_data_t **const subTlvP, size_t *const count) {
+    if (dataP->type == LWM2M_TYPE_MULTIPLE_RESOURCE) {
+        (*count) = dataP->value.asChildren.count;
+        (*subTlvP) = dataP->value.asChildren.array;
+    } else {
+        (*count) = 1; // reduced to 1 instance to fit in one block size
+        (*subTlvP) = lwm2m_data_new((*count));
+        for (size_t i = 0; i < (*count); i++)
+            (*subTlvP)[i].id = i;
+        lwm2m_data_encode_instances((*subTlvP), (*count), dataP);
+    }
+}
+
 static uint8_t prv_set_value(lwm2m_data_t * dataP,
                              conn_m_data_t * connDataP)
 {
@@ -102,18 +115,7 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
 
     case RES_M_AVL_NETWORK_BEARER:
     {
-        if (dataP->type == LWM2M_TYPE_MULTIPLE_RESOURCE)
-        {
-            count = dataP->value.asChildren.count;
-            subTlvP = dataP->value.asChildren.array;
-        }
-        else
-        {
-            count = 1; // reduced to 1 instance to fit in one block size
-            subTlvP = lwm2m_data_new(count);
-            for (i = 0; i < count; i++) subTlvP[i].id = i;
-            lwm2m_data_encode_instances(subTlvP, count, dataP);
-        }
+        reduce_single_instance(dataP, &subTlvP, &count);
 
         for (i = 0; i < count; i++)
         {
@@ -141,18 +143,7 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
 
     case RES_M_IP_ADDRESSES:
     {
-        if (dataP->type == LWM2M_TYPE_MULTIPLE_RESOURCE)
-        {
-            count = dataP->value.asChildren.count;
-            subTlvP = dataP->value.asChildren.array;
-        }
-        else
-        {
-            count = 1; // reduced to 1 instance to fit in one block size
-            subTlvP = lwm2m_data_new(count);
-            for (i = 0; i < count; i++) subTlvP[i].id = i;
-            lwm2m_data_encode_instances(subTlvP, count, dataP);
-        }
+        reduce_single_instance(dataP, &subTlvP, &count);
 
         for (i = 0; i < count; i++)
         {
@@ -204,18 +195,7 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
 
     case RES_O_APN:
     {
-        if (dataP->type == LWM2M_TYPE_MULTIPLE_RESOURCE)
-        {
-            count = dataP->value.asChildren.count;
-            subTlvP = dataP->value.asChildren.array;
-        }
-        else
-        {
-            count = 1; // reduced to 1 instance to fit in one block size
-            subTlvP = lwm2m_data_new(count);
-            for (i = 0; i < count; i++) subTlvP[i].id = i;
-            lwm2m_data_encode_instances(subTlvP, count, dataP);
-        }
+        reduce_single_instance(dataP, &subTlvP, &count);
 
         for (i = 0; i < count; i++)
         {

--- a/examples/client/object_server.c
+++ b/examples/client/object_server.c
@@ -47,10 +47,10 @@
 
 #include "liblwm2m.h"
 
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <limits.h>
 
 typedef struct _server_instance_
 {
@@ -239,6 +239,12 @@ static void remove_optional_resource(uint16_t *resList, int val, const uint_fast
     }
 }
 
+static void setup_resources(lwm2m_data_t *const *dataArrayP, const uint16_t *const resList, const size_t nbRes) {
+    for (size_t i = 0; i < nbRes; i++) {
+        (*dataArrayP)[i].id = resList[i];
+    }
+}
+
 /** Remove optional resources that don't exist */
 static void remove_all_optional_resources(uint16_t *resList, server_instance_t *targetP, ssize_t *nbRes) {
     remove_optional_resource(resList, targetP->registrationPriorityOrder, LWM2M_SERVER_REG_ORDER_ID, nbRes);
@@ -274,7 +280,6 @@ static uint8_t prv_server_read(lwm2m_context_t *contextP,
 {
     server_instance_t * targetP;
     uint8_t result;
-    int i;
 
     /* unused parameter */
     (void)contextP;
@@ -307,10 +312,7 @@ static uint8_t prv_server_read(lwm2m_context_t *contextP,
         *dataArrayP = lwm2m_data_new(nbRes);
         if (*dataArrayP == NULL) return COAP_500_INTERNAL_SERVER_ERROR;
         *numDataP = nbRes;
-        for (i = 0 ; i < nbRes ; i++)
-        {
-            (*dataArrayP)[i].id = resList[i];
-        }
+        setup_resources(dataArrayP, resList, nbRes);
     }
 
     result = prv_get_all_values(numDataP, dataArrayP, targetP);
@@ -362,10 +364,7 @@ static uint8_t prv_server_discover(lwm2m_context_t *contextP,
         *dataArrayP = lwm2m_data_new(nbRes);
         if (*dataArrayP == NULL) return COAP_500_INTERNAL_SERVER_ERROR;
         *numDataP = nbRes;
-        for (i = 0; i < nbRes; i++)
-        {
-            (*dataArrayP)[i].id = resList[i];
-        }
+        setup_resources(dataArrayP, resList, nbRes);
     }
     else
     {

--- a/examples/client/object_server.c
+++ b/examples/client/object_server.c
@@ -252,6 +252,20 @@ static void remove_all_optional_resources(uint16_t *resList, server_instance_t *
     remove_optional_resource(resList, targetP->communicationSequenceRetryCount, LWM2M_SERVER_SEQ_RETRY_COUNT_ID, nbRes);
 }
 
+static uint8_t prv_get_all_values(const int *numDataP, lwm2m_data_t *const *dataArrayP,
+                                  server_instance_t *const targetP) {
+    int i = 0;
+    uint8_t result;
+    do {
+        if ((*dataArrayP)[i].type == LWM2M_TYPE_MULTIPLE_RESOURCE) {
+            result = COAP_404_NOT_FOUND;
+        } else {
+            result = prv_get_value((*dataArrayP) + i, targetP);
+        }
+        i++;
+    } while (i < *numDataP && result == COAP_205_CONTENT);
+    return result;
+}
 static uint8_t prv_server_read(lwm2m_context_t *contextP,
                                uint16_t instanceId,
                                int * numDataP,
@@ -299,19 +313,7 @@ static uint8_t prv_server_read(lwm2m_context_t *contextP,
         }
     }
 
-    i = 0;
-    do
-    {
-        if ((*dataArrayP)[i].type == LWM2M_TYPE_MULTIPLE_RESOURCE)
-        {
-            result = COAP_404_NOT_FOUND;
-        }
-        else
-        {
-            result = prv_get_value((*dataArrayP) + i, targetP);
-        }
-        i++;
-    } while (i < *numDataP && result == COAP_205_CONTENT);
+    result = prv_get_all_values(numDataP, dataArrayP, targetP);
 
     return result;
 }


### PR DESCRIPTION
A lot of code was copy-and-pasted several times and functions were too long.

This is done to make Sonar Cloud happy. It considers moved files to be new code and complains about not beeing conformant.

But it's anyway good to have some clean-ups.