### PR TITLE
Include OpenSSF score card

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,58 @@
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '30 4 * * 0'
+  push:
+    branches:
+      - gardena/rs/upstream/run-openssf-score-card
+      - main
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # - Publish results to OpenSSF REST API for easy access by consumers
+          # - Allows the repository to include the Scorecard badge.
+          # - See https://github.com/ossf/scorecard-action#publishing-results.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build](https://github.com/eclipse/wakaama/actions/workflows/build_and_test.yaml/badge.svg)](https://github.com/eclipse/wakaama/actions/workflows/build_and_test.yaml)
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/eclipse-wakaama/wakaama/badge)](https://scorecard.dev/viewer/?uri=github.com/eclipse-wakaama/wakaama)
+
 Wakaama (formerly liblwm2m) is an implementation of the Open Mobile Alliance's LightWeight M2M
 protocol (LWM2M).
 


### PR DESCRIPTION
As designed by the OpenSSF, this workflow will work only it has been merged to main:
```
2024/11/10 09:08:32 creating scorecard entrypoint: validating options: only default branch is supported
EnvGithubAuthToken: GITHUB_AUTH_TOKEN ***
refs/heads/gardena/rs/upstream/run-openssf-score-card not supported with push event.
Only the default branch main is supported.
```

Until then, the following can be done to verify this:
- Apply this PR to main of a dedicated testing fork (e.g. https://github.com/rettichschnidi/wakaama/commit/0e266917cbde85d8482824ca68e1849aacdabbda)
- Check out the score card [generated by the OpenSSF](https://scorecard.dev/viewer/?uri=github.com/eclipse/wakaama) (unfortunately, they are still using the old URL)
- Check out the badge generated by the OpenSSF: [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/eclipse/wakaama/badge)](https://scorecard.dev/viewer/?uri=github.com/eclipse/wakaama) (unfortunately, they are still using the old URL)