### PR TITLE
ci: Update `run-on-arch-action`

### DIFF
--- a/.github/workflows/multiarch.yaml
+++ b/.github/workflows/multiarch.yaml
@@ -16,7 +16,7 @@ jobs:
         submodules: true
         fetch-depth: 0
     - name: Build and test
-      uses: uraimo/run-on-arch-action@v2.7.2
+      uses: uraimo/run-on-arch-action@v2.8.1
       id: runcmd
       with:
         arch: ${{ matrix.arch }}


### PR DESCRIPTION
The action failed with:

"ERROR: failed to solve: arm32v7/debian:bookworm: failed to resolve source metadata for docker.io/arm32v7/debian:bookworm"