### PR TITLE
ci: scorecard: Remove non-main branch

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,7 +9,6 @@ on:
     - cron: '30 4 * * 0'
   push:
     branches:
-      - gardena/rs/upstream/run-openssf-score-card
       - main
 
 permissions: read-all


### PR DESCRIPTION
This branch name has been accidentally committed in 220362caf725e9c540c071eca289185fc4c056f5 (ci: Add OSSF Scorecard action).