### PR TITLE
ci: Cancel outdated runs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,10 @@ name: Compilation only checks
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   standards:
     runs-on: ubuntu-24.04

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: '**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_and_test:
     runs-on: ubuntu-24.04

--- a/.github/workflows/clang-static-analyzer.yaml
+++ b/.github/workflows/clang-static-analyzer.yaml
@@ -2,6 +2,10 @@ name: Clang Static Analyzer
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   clang_static_analyzer:
     runs-on: ubuntu-24.04

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '20 14 * * 1'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   codeql:
     runs-on: ubuntu-24.04

--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -2,6 +2,10 @@ name: Compliance
 
 on: pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-code:
     name: Run compliance checks

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -2,6 +2,10 @@ name: Measure coverage
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   coverage:
     runs-on: ubuntu-24.04

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   documentation:
     runs-on: ubuntu-24.04

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: '**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_and_test:
     runs-on: macos-14

--- a/.github/workflows/multiarch.yaml
+++ b/.github/workflows/multiarch.yaml
@@ -2,6 +2,10 @@ name: Foreign architectures
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   multiarch:
     runs-on: ubuntu-24.04

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: read-all
 
 jobs:

--- a/.github/workflows/sonarcloud-scan.yaml
+++ b/.github/workflows/sonarcloud-scan.yaml
@@ -2,6 +2,10 @@ name: SonarCloud Scan
 
 on: [push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sonarcloud:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Canceling builds of commits which are no longer (really) relevant seems like a sensible thing to do.