### PR TITLE
Fix repository name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ syntax and access rights and then dispatches them to the relevant objects.
 
 The project maintains the following source code repositories
 
-* https://github.com/eclipse/wakaama
+* https://github.com/eclipse-wakaama/wakaama
 
 This project uses GitHub issues to track ongoing development and issues.
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -25,7 +25,7 @@ A copy of the EDL is available at http://www.eclipse.org/org/documents/edl-v10.p
 
 The project maintains the following source code repositories:
 
-* https://github.com/eclipse/wakaama
+* https://github.com/eclipse-wakaama/wakaama
 
 ## Third-party Content
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wakaama
 
-[![Build](https://github.com/eclipse/wakaama/actions/workflows/build_and_test.yaml/badge.svg)](https://github.com/eclipse/wakaama/actions/workflows/build_and_test.yaml)
+[![Build](https://github.com/eclipse-wakaama/wakaama/actions/workflows/build_and_test.yaml/badge.svg)](https://github.com/eclipse/wakaama/actions/workflows/build_and_test.yaml)
 
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/eclipse-wakaama/wakaama/badge)](https://scorecard.dev/viewer/?uri=github.com/eclipse-wakaama/wakaama)
 
@@ -33,7 +33,7 @@ This work is dual-licensed under the Eclipse Public License v2.0 and Eclipse Dis
 ### Using Wakaama as library
 
 ```
-git clone https://github.com/eclipse/wakaama.git
+git clone https://github.com/eclipse-wakaama/wakaama.git
 ```
 
 ### Working on Wakaama
@@ -41,7 +41,7 @@ git clone https://github.com/eclipse/wakaama.git
 When working on Wakaama itself, or intending to run the example client application, submodules must be checked out:
 
 ```
-git clone --recurse-submodules https://github.com/eclipse/wakaama.git
+git clone --recurse-submodules https://github.com/eclipse-wakaama/wakaama.git
 ```
 
 ## Compiling

--- a/examples/shared/platform.c
+++ b/examples/shared/platform.c
@@ -72,7 +72,7 @@ int lwm2m_seed(void) {
      * Return a seed for random number generation, the seed must be a
      * different number at every boot and unpredictable, time(NULL) may not be
      * a reliable source as a seed.
-     * See: https://github.com/eclipse/wakaama/pull/711
+     * See: https://github.com/eclipse-wakaama/wakaama/pull/711
      */
     return time(NULL);
 }

--- a/tests/data_senml_json_tests.c
+++ b/tests/data_senml_json_tests.c
@@ -531,7 +531,7 @@ static void senml_json_test_23(void) {
                                      strlen(buffer));
     lwm2m_data_free(1, dataP);
 
-    /* This test is added for https://github.com/eclipse/wakaama/issues/274 */
+    /* This test is added for https://github.com/eclipse-wakaama/wakaama/issues/274 */
     const char *buffer2 = "[{\"bn\":\"/34/0/2\",\"vd\":\"MA==\"}]";
     senml_json_test_raw("/34/0/2", (uint8_t *)buffer2, strlen(buffer2), LWM2M_CONTENT_SENML_JSON, "23c");
 }


### PR DESCRIPTION
While https://github.com/eclipse/wakaama redirects to https://github.com/eclipse-wakaama/wakaama, the later is what should be used nowadays.