### PR TITLE
coap: Cleanup transactions when client is unregistered

### DIFF
--- a/coap/transaction.c
+++ b/coap/transaction.c
@@ -527,3 +527,22 @@ bool transaction_free_userData(lwm2m_context_t * context, lwm2m_transaction_t * 
     transaction->userData = NULL;
     return true;
 }
+
+/*
+ * Remove transactions from a specific client.
+ */
+void transaction_remove_client(lwm2m_context_t *contextP, lwm2m_client_t *clientP) {
+    lwm2m_transaction_t *transacP;
+
+    LOG_DBG("Entering");
+    transacP = contextP->transactionList;
+    while (transacP != NULL) {
+        lwm2m_transaction_t *nextP = transacP->next;
+
+        if (lwm2m_session_is_equal(transacP->peerH, clientP->sessionH, contextP->userData)) {
+            LOG_DBG("Found session to remove");
+            transaction_remove(contextP, transacP);
+        }
+        transacP = nextP;
+    }
+}

--- a/core/internals.h
+++ b/core/internals.h
@@ -263,6 +263,7 @@ void transaction_remove(lwm2m_context_t * contextP, lwm2m_transaction_t * transa
 bool transaction_handleResponse(lwm2m_context_t * contextP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
 void transaction_step(lwm2m_context_t * contextP, time_t currentTime, time_t * timeoutP);
 bool transaction_free_userData(lwm2m_context_t * context, lwm2m_transaction_t * transaction);
+void transaction_remove_client(lwm2m_context_t *contextP, lwm2m_client_t *clientP);
 bool transaction_set_payload(lwm2m_transaction_t *transaction, uint8_t *buffer, size_t length);
 
 #ifdef LWM2M_SUPPORT_TLV

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -218,7 +218,7 @@ void lwm2m_close(lwm2m_context_t * contextP)
         clientP = contextP->clientList;
         contextP->clientList = contextP->clientList->next;
 
-        registration_freeClient(clientP);
+        registration_freeClient(contextP, clientP);
     }
 #endif
 

--- a/core/registration.c
+++ b/core/registration.c
@@ -1721,8 +1721,7 @@ static lwm2m_client_t * prv_getClientByName(lwm2m_context_t * contextP,
     return targetP;
 }
 
-void registration_freeClient(lwm2m_client_t * clientP)
-{
+void registration_freeClient(lwm2m_context_t *const context, lwm2m_client_t *clientP) {
     LOG_DBG("Entering");
     if (clientP->name != NULL) lwm2m_free(clientP->name);
     if (clientP->msisdn != NULL) lwm2m_free(clientP->msisdn);
@@ -1744,6 +1743,8 @@ void registration_freeClient(lwm2m_client_t * clientP)
 
         free_block_data(targetP);
     }
+    transaction_remove_client(context, clientP);
+    lwm2m_session_remove(clientP->sessionH);
     lwm2m_free(clientP);
 }
 
@@ -1858,7 +1859,7 @@ uint8_t  registration_handleRequest(lwm2m_context_t * contextP,
                 {
                     lwm2m_client_t * tmpClientP = utils_findClient(contextP, fromSessionH);
                     contextP->clientList = (lwm2m_client_t *)LWM2M_LIST_RM(contextP->clientList, tmpClientP->internalID, &tmpClientP);
-                    registration_freeClient(tmpClientP);
+                    registration_freeClient(contextP, tmpClientP);
                 }
             }
             if (clientP != NULL)
@@ -1898,12 +1899,12 @@ uint8_t  registration_handleRequest(lwm2m_context_t * contextP,
 
             if (prv_getLocationString(clientP->internalID, location) == 0)
             {
-                registration_freeClient(clientP);
+                registration_freeClient(contextP, clientP);
                 return COAP_500_INTERNAL_SERVER_ERROR;
             }
             if (coap_set_header_location_path(response, location) == 0)
             {
-                registration_freeClient(clientP);
+                registration_freeClient(contextP, clientP);
                 return COAP_500_INTERNAL_SERVER_ERROR;
             }
 
@@ -2023,7 +2024,7 @@ uint8_t  registration_handleRequest(lwm2m_context_t * contextP,
         {
             contextP->monitorCallback(contextP, clientP->internalID, NULL, COAP_202_DELETED, NULL, LWM2M_CONTENT_TEXT, NULL, 0, contextP->monitorUserData);
         }
-        registration_freeClient(clientP);
+        registration_freeClient(contextP, clientP);
         result = COAP_202_DELETED;
     }
     break;
@@ -2143,7 +2144,7 @@ void registration_step(lwm2m_context_t * contextP,
             {
                 contextP->monitorCallback(contextP, clientP->internalID, NULL, COAP_202_DELETED, NULL, LWM2M_CONTENT_TEXT, NULL, 0, contextP->monitorUserData);
             }
-            registration_freeClient(clientP);
+            registration_freeClient(contextP, clientP);
         }
         else
         {

--- a/core/registration.h
+++ b/core/registration.h
@@ -23,7 +23,7 @@
 uint8_t registration_handleRequest(lwm2m_context_t *contextP, lwm2m_uri_t *uriP, void *fromSessionH,
                                    coap_packet_t *message, coap_packet_t *response);
 void registration_deregister(lwm2m_context_t *contextP, lwm2m_server_t *serverP);
-void registration_freeClient(lwm2m_client_t *clientP);
+void registration_freeClient(lwm2m_context_t *contextP, lwm2m_client_t *clientP);
 uint8_t registration_start(lwm2m_context_t *contextP, bool restartFailed);
 void registration_step(lwm2m_context_t *contextP, time_t currentTime, time_t *timeoutP);
 lwm2m_status_t registration_getStatus(lwm2m_context_t *contextP);

--- a/include/liblwm2m.h
+++ b/include/liblwm2m.h
@@ -158,6 +158,11 @@ uint8_t lwm2m_buffer_send(void * sessionH, uint8_t * buffer, size_t length, void
 bool lwm2m_session_is_equal(void * session1, void * session2, void * userData);
 
 /*
+ * Remove session from list
+ */
+void lwm2m_session_remove(void *sessionH);
+
+/*
  * Error code
  */
 

--- a/tests/helper/connection.c
+++ b/tests/helper/connection.c
@@ -50,3 +50,10 @@ uint8_t *test_get_response_buffer(size_t *len) {
     *len = response_len;
     return response_buffer;
 }
+
+void lwm2m_session_remove(void *sessionH) {
+    (void)sessionH;
+
+    // Currently the tests do not use a session structure, assume a NULL pointer here.
+    assert(sessionH == NULL);
+}

--- a/transport/udp/connection.c
+++ b/transport/udp/connection.c
@@ -213,3 +213,5 @@ bool lwm2m_session_is_equal(void *session1, void *session2, void *userData) {
 
     return (session1 == session2);
 }
+
+void lwm2m_session_remove(void *session_h) { (void)session_h; /* unused */ }


### PR DESCRIPTION
All pending transactions of a just unregistered client must be removed