### PR TITLE
server: Make client context available in de-registration callback

### DIFF
--- a/core/registration.c
+++ b/core/registration.c
@@ -2017,12 +2017,17 @@ uint8_t  registration_handleRequest(lwm2m_context_t * contextP,
         if (!LWM2M_URI_IS_SET_OBJECT(uriP)) return COAP_400_BAD_REQUEST;
         if (LWM2M_URI_IS_SET_INSTANCE(uriP)) return COAP_400_BAD_REQUEST;
 
-        contextP->clientList = (lwm2m_client_t *)LWM2M_LIST_RM(contextP->clientList, uriP->objectId, &clientP);
-        if (clientP == NULL) return COAP_400_BAD_REQUEST;
-        if (contextP->monitorCallback != NULL)
-        {
-            contextP->monitorCallback(contextP, clientP->internalID, NULL, COAP_202_DELETED, NULL, LWM2M_CONTENT_TEXT, NULL, 0, contextP->monitorUserData);
+        clientP = (lwm2m_client_t *)LWM2M_LIST_FIND(contextP->clientList, uriP->objectId);
+
+        if (clientP == NULL) {
+            return COAP_400_BAD_REQUEST;
         }
+
+        if (contextP->monitorCallback != NULL) {
+            contextP->monitorCallback(contextP, clientP->internalID, NULL, COAP_202_DELETED, NULL, LWM2M_CONTENT_TEXT,
+                                      NULL, 0, contextP->monitorUserData);
+        }
+        contextP->clientList = (lwm2m_client_t *)LWM2M_LIST_RM(contextP->clientList, clientP->internalID, NULL);
         registration_freeClient(clientP);
         result = COAP_202_DELETED;
     }
@@ -2136,17 +2141,14 @@ void registration_step(lwm2m_context_t * contextP,
     {
         lwm2m_client_t * nextP = clientP->next;
 
-        if (clientP->endOfLife <= currentTime)
-        {
-            contextP->clientList = (lwm2m_client_t *)LWM2M_LIST_RM(contextP->clientList, clientP->internalID, NULL);
-            if (contextP->monitorCallback != NULL)
-            {
-                contextP->monitorCallback(contextP, clientP->internalID, NULL, COAP_202_DELETED, NULL, LWM2M_CONTENT_TEXT, NULL, 0, contextP->monitorUserData);
+        if (clientP->endOfLife <= currentTime) {
+            if (contextP->monitorCallback != NULL) {
+                contextP->monitorCallback(contextP, clientP->internalID, NULL, COAP_202_DELETED, NULL,
+                                          LWM2M_CONTENT_TEXT, NULL, 0, contextP->monitorUserData);
             }
+            contextP->clientList = (lwm2m_client_t *)LWM2M_LIST_RM(contextP->clientList, clientP->internalID, NULL);
             registration_freeClient(clientP);
-        }
-        else
-        {
+        } else {
             time_t interval;
 
             interval = clientP->endOfLife - currentTime;

--- a/examples/server/lwm2mserver.c
+++ b/examples/server/lwm2mserver.c
@@ -953,19 +953,17 @@ syntax_error:
 static void prv_monitor_callback(lwm2m_context_t *lwm2mH, uint16_t clientID, lwm2m_uri_t *uriP, int status,
                                  block_info_t *block_info, lwm2m_media_type_t format, uint8_t *data, size_t dataLength,
                                  void *userData) {
-    lwm2m_client_t * targetP;
+    lwm2m_client_t *clientP;
 
     /* unused parameter */
     (void)userData;
+
+    clientP = (lwm2m_client_t *)LWM2M_LIST_FIND(lwm2mH->clientList, clientID);
 
     switch (status)
     {
     case COAP_201_CREATED:
         fprintf(stdout, "\r\nNew client #%d registered.\r\n", clientID);
-
-        targetP = (lwm2m_client_t *)lwm2m_list_find((lwm2m_list_t *)lwm2mH->clientList, clientID);
-
-        prv_dump_client(targetP);
         break;
 
     case COAP_202_DELETED:
@@ -974,16 +972,13 @@ static void prv_monitor_callback(lwm2m_context_t *lwm2mH, uint16_t clientID, lwm
 
     case COAP_204_CHANGED:
         fprintf(stdout, "\r\nClient #%d updated.\r\n", clientID);
-
-        targetP = (lwm2m_client_t *)lwm2m_list_find((lwm2m_list_t *)lwm2mH->clientList, clientID);
-
-        prv_dump_client(targetP);
         break;
 
     default:
         fprintf(stdout, "\r\nMonitor callback called with an unknown status: %d.\r\n", status);
         break;
     }
+    prv_dump_client(clientP);
 
     fprintf(stdout, "\r\n> ");
     fflush(stdout);


### PR DESCRIPTION
Remove the client context from server only after calling the monitoring callback when handling a de-registration. A as result, the client information is still available in the server context during the callback.