### PR TITLE
ci: Remove defunct foreign architectures from actions

### DIFF
--- a/.github/workflows/multiarch.yaml
+++ b/.github/workflows/multiarch.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ["armv6", "armv7", "aarch64", "s390x", "ppc64le"]
+        arch: ["armv6", "armv7"]
     steps:
     - name: Checkout code including full history and submodules
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
The compiler produces a segfault on the emulated architecture. To be able to continue the work on Wakaama we disable testing on that architecture for the time being.