### PR TITLE
cmake: Add option for disabling unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ project(wakaama C)
 
 include(wakaama.cmake)
 
-# Enable "test" target
-enable_testing()
-add_subdirectory(tests)
+option(WAKAAMA_UNIT_TESTS "Enable build of Unit Tests" ON)
+
+if(WAKAAMA_UNIT_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ tools/ci/run_ci.sh --run-build
 pytest -v tests/integration
 ```
 
+### Disabling Unit Tests
+
+Building the unit tests can be controlled by the CMake cache variable:
+
+- `WAKAAMA_UNIT_TESTS`: The tests are enabled by default
+
 ## Examples
 
 There are some example applications provided to test the server, client and bootstrap capabilities of Wakaama.


### PR DESCRIPTION
Building the unit tests can now be disabled with a CMake cache variable. This is useful on platforms where `CUnit` is not available or when working on an embedded platform.