### PR TITLE
cmake: Make max retransmit configurable at build time

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The following data formats are configurable for Wakaama:
 - WAKAAMA_COAP_RAW_BLOCK1_REQUESTS For low memory client devices where it is not possible to keep a large post or put request in memory to be parsed (typically a firmware write).
   This option enable each unprocessed block 1 payload to be passed to the application, typically to be stored to a flash memory.
 - WAKAAMA_COAP_DEFAULT_BLOCK_SIZE CoAP block size used by CoAP layer when performing block-wise transfers. Possible values: 16, 32, 64, 128, 256, 512 and 1024. Defaults to 1024.
+- WAKAAMA_COAP_DEFAULT_MAX_RETRANSMIT The maximum number of retransmissions used for confirmable messages.
 
 
 ### Logging

--- a/coap/er-coap-13/er-coap-13.h
+++ b/coap/er-coap-13/er-coap-13.h
@@ -48,7 +48,7 @@
 
 #define COAP_DEFAULT_MAX_AGE                 60
 #define COAP_RESPONSE_TIMEOUT                2
-#define COAP_MAX_RETRANSMIT                  4
+#define COAP_MAX_RETRANSMIT                  LWM2M_COAP_DEFAULT_MAX_RETRANSMIT
 #define COAP_ACK_RANDOM_FACTOR               1.5
 #define COAP_MAX_LATENCY                     100
 #define COAP_PROCESSING_DELAY                COAP_RESPONSE_TIMEOUT

--- a/wakaama.cmake
+++ b/wakaama.cmake
@@ -44,6 +44,12 @@ set_property(
              1024
 )
 
+# The maximum number of retransmissions used for confirmable messages.
+set(WAKAAMA_COAP_DEFAULT_MAX_RETRANSMIT
+    4
+    CACHE STRING "Default CoAP max retransmissions"
+)
+
 # Logging
 set(WAKAAMA_LOG_LEVEL
     LOG_DISABLED
@@ -144,6 +150,10 @@ function(set_coap_defines)
     endif()
 
     target_compile_definitions(${target} PUBLIC LWM2M_COAP_DEFAULT_BLOCK_SIZE=${WAKAAMA_COAP_DEFAULT_BLOCK_SIZE})
+
+    target_compile_definitions(
+        ${target} PUBLIC LWM2M_COAP_DEFAULT_MAX_RETRANSMIT=${WAKAAMA_COAP_DEFAULT_MAX_RETRANSMIT}
+    )
 endfunction()
 
 # Set the defines for logging configuration
@@ -237,17 +247,6 @@ function(target_sources_wakaama target)
     if(NOT CURRENT_TARGET_COMPILE_DEFINITIONS MATCHES "LWM2M_COAP_DEFAULT_BLOCK_SIZE=")
         target_compile_definitions(${target} PRIVATE "LWM2M_COAP_DEFAULT_BLOCK_SIZE=${LWM2M_COAP_DEFAULT_BLOCK_SIZE}")
         message(STATUS "${target}: Default CoAP block size not set, using ${LWM2M_COAP_DEFAULT_BLOCK_SIZE}")
-    endif()
-
-    # LWM2M_COAP_DEFAULT_MAX_RETRANSMIT is needed by source files -> always set it
-    if(NOT CURRENT_TARGET_COMPILE_DEFINITIONS MATCHES "LWM2M_COAP_DEFAULT_MAX_RETRANSMIT=")
-        target_compile_definitions(
-            ${target} PRIVATE "LWM2M_COAP_DEFAULT_MAX_RETRANSMIT=${LWM2M_COAP_DEFAULT_MAX_RETRANSMIT}"
-        )
-        message(
-            STATUS
-                "${target}: Default CoAP max retransmission count not set, using ${LWM2M_COAP_DEFAULT_MAX_RETRANSMIT}"
-        )
     endif()
 
     # Detect invalid configuration already during CMake run
@@ -349,10 +348,4 @@ add_compile_options(
 set(LWM2M_COAP_DEFAULT_BLOCK_SIZE
     1024
     CACHE STRING "Default CoAP block size; Used if not set on a per-target basis"
-)
-
-# The maximum number of retransmissions used for confirmable messages.
-set(LWM2M_COAP_DEFAULT_MAX_RETRANSMIT
-    4
-    CACHE STRING "Default CoAP max retransmissions; Used if not set on a per-target basis"
 )

--- a/wakaama.cmake
+++ b/wakaama.cmake
@@ -239,6 +239,17 @@ function(target_sources_wakaama target)
         message(STATUS "${target}: Default CoAP block size not set, using ${LWM2M_COAP_DEFAULT_BLOCK_SIZE}")
     endif()
 
+    # LWM2M_COAP_DEFAULT_MAX_RETRANSMIT is needed by source files -> always set it
+    if(NOT CURRENT_TARGET_COMPILE_DEFINITIONS MATCHES "LWM2M_COAP_DEFAULT_MAX_RETRANSMIT=")
+        target_compile_definitions(
+            ${target} PRIVATE "LWM2M_COAP_DEFAULT_MAX_RETRANSMIT=${LWM2M_COAP_DEFAULT_MAX_RETRANSMIT}"
+        )
+        message(
+            STATUS
+                "${target}: Default CoAP max retransmission count not set, using ${LWM2M_COAP_DEFAULT_MAX_RETRANSMIT}"
+        )
+    endif()
+
     # Detect invalid configuration already during CMake run
     if(NOT CURRENT_TARGET_COMPILE_DEFINITIONS MATCHES "LWM2M_SERVER_MODE|LWM2M_BOOTSTRAP_SERVER_MODE|LWM2M_CLIENT_MODE")
         message(FATAL_ERROR "${target}: At least one mode (client, server, bootstrap server) must be enabled!")
@@ -338,4 +349,10 @@ add_compile_options(
 set(LWM2M_COAP_DEFAULT_BLOCK_SIZE
     1024
     CACHE STRING "Default CoAP block size; Used if not set on a per-target basis"
+)
+
+# The maximum number of retransmissions used for confirmable messages.
+set(LWM2M_COAP_DEFAULT_MAX_RETRANSMIT
+    4
+    CACHE STRING "Default CoAP max retransmissions; Used if not set on a per-target basis"
 )


### PR DESCRIPTION
Make CoAP max retransmit setting configurable at build time.