### PR TITLE
coap: Check for duplicate messages

### DIFF
--- a/coap/message_dedup.c
+++ b/coap/message_dedup.c
@@ -1,0 +1,87 @@
+/*
+ * CoAP message deduplication tracking.
+ * RFC7252 section 4.2
+ */
+
+#include <stdbool.h>
+
+#include "message_dedup.h"
+#include <internals.h>
+#include <liblwm2m.h>
+
+void coap_cleanup_message_deduplication_step(coap_msg_dedup_t **message_dedup, const time_t current_time,
+                                             time_t *timeout) {
+    LOG_DBG("Entering");
+    coap_msg_dedup_t *message_dedup_check = *message_dedup;
+    coap_msg_dedup_t *message_dedup_check_prev = *message_dedup;
+    while (message_dedup_check != NULL) {
+        time_t diff = current_time - message_dedup_check->timestamp;
+        if (diff >= EXCHANGE_LIFETIME) {
+            LOG_DBG("Message %d deduplication period ended", message_dedup_check->mid);
+            if (message_dedup_check_prev != *message_dedup) {
+                message_dedup_check_prev->next = message_dedup_check->next;
+            } else {
+                *message_dedup = message_dedup_check->next;
+                message_dedup_check_prev = message_dedup_check->next;
+            }
+            coap_msg_dedup_t *message_dedup_check_next = message_dedup_check->next;
+            lwm2m_free(message_dedup_check);
+            message_dedup_check = message_dedup_check_next;
+        } else {
+            LOG_DBG("Message %d check deduplication", message_dedup_check->mid);
+            time_t message_dedup_timeout;
+            if ((message_dedup_timeout = (message_dedup_check->timestamp + EXCHANGE_LIFETIME) - current_time) < 0) {
+                message_dedup_timeout = 0;
+            }
+            if (message_dedup_timeout < *timeout) {
+                LOG_DBG("Message %d check again in %ds deduplication", message_dedup_check->mid, message_dedup_timeout);
+                *timeout = message_dedup_timeout;
+            }
+            message_dedup_check_prev = message_dedup_check;
+            message_dedup_check = message_dedup_check->next;
+        }
+    }
+}
+
+bool coap_check_message_duplication(coap_msg_dedup_t **message_dedup, const uint16_t mid, const void *session) {
+    LOG_DBG("Entering");
+    coap_msg_dedup_t *message_dedup_check = *message_dedup;
+    while (message_dedup_check != NULL) {
+        bool is_equal = lwm2m_session_is_equal(message_dedup_check->session, (void *)session, NULL);
+        if (message_dedup_check->mid == mid && is_equal) {
+            LOG_DBG("Duplicate, ignore mid %d (session: %p)", mid, session);
+            return true;
+        }
+        message_dedup_check = message_dedup_check->next;
+    }
+    LOG_DBG("Register mid %d (session: %p) for deduplication check", mid, session);
+    /* The message was not received in the past. Remember for future checks. */
+    coap_msg_dedup_t *new_message;
+    new_message = lwm2m_malloc(sizeof(coap_msg_dedup_t));
+    if (new_message == NULL) {
+        /* Memory allocation failed, mark packet as duplicate. Further allocations during packet processing would fail
+         * anyway. */
+        return true;
+    }
+    memset(new_message, 0, sizeof(coap_msg_dedup_t));
+    new_message->mid = mid;
+    new_message->session = (void *)session;
+    new_message->timestamp = lwm2m_gettime();
+
+    /* Add message id to deduplication list */
+    coap_msg_dedup_t *message_dedup_temp = *message_dedup;
+    *message_dedup = new_message;
+    (*message_dedup)->next = message_dedup_temp;
+
+    return false;
+}
+
+void coap_deduplication_free(lwm2m_context_t *ctx) {
+    LOG_DBG("Remove and free the whole message deduplication list");
+    while (ctx->message_dedup != NULL) {
+        coap_msg_dedup_t *msg_dedup;
+        msg_dedup = ctx->message_dedup;
+        ctx->message_dedup = ctx->message_dedup->next;
+        lwm2m_free(msg_dedup);
+    }
+}

--- a/coap/message_dedup.h
+++ b/coap/message_dedup.h
@@ -1,0 +1,42 @@
+#ifndef _COAP_MESSAGE_DEDUP_H_
+#define _COAP_MESSAGE_DEDUP_H_
+
+#include <stdint.h>
+#include <time.h>
+
+#include <liblwm2m.h>
+
+/*
+ * EXCHANGE_LIFETIME https://datatracker.ietf.org/doc/html/rfc7252#section-4.8.2
+ * Time to block message ids from a client to prevent receiving duplicate packets.
+ * Special value for Lemonbeat transmissions: Expected worst case latency per packet: 1s.
+ * EXCHANGE_LIFETIME = (ACK_TIMEOUT * ((2 ** MAX_RETRANSMIT) - 1) + LEMONBEAT_DELAY) * ACK_RANDOM_FACTOR
+ * With ACK_RANDOM_FACTOR=1.5, LEMONBEAT_DELAY=1, MAX_RETRANSMIT=4
+ * (2 * ((2 ** 4) - 1) + 1) * 1.5 = 46.5 -> ~47s
+ */
+#define EXCHANGE_LIFETIME 47
+
+/**
+ * Cleanup message ids after EXCHANGE_LIFETIME.
+ * @param message_dedup list of message ids for deduplication
+ * @param current_time current timestamp
+ * @param timeout next timeout in main loop
+ */
+void coap_cleanup_message_deduplication_step(coap_msg_dedup_t **message_dedup, time_t current_time, time_t *timeout);
+
+/**
+ * Check whether a message was already received.
+ * @param message_dedup list of message ids for deduplication
+ * @param mid message id
+ * @param session pointer to the session the message was received from
+ * @return true if the message was already seen within in the EXCHANGE_LIFETIME window, false otherwise.
+ */
+bool coap_check_message_duplication(coap_msg_dedup_t **message_dedup, uint16_t mid, const void *session);
+
+/**
+ * Remove and free the whole message deduplication list
+ * @param ctx lwm2m context
+ */
+void coap_deduplication_free(lwm2m_context_t *ctx);
+
+#endif // _COAP_MESSAGE_DEDUP_H_

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -51,6 +51,7 @@
 */
 
 #include "internals.h"
+#include "message_dedup.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -223,6 +224,7 @@ void lwm2m_close(lwm2m_context_t * contextP)
 #endif
 
     prv_deleteTransactionList(contextP);
+    coap_deduplication_free(contextP);
     lwm2m_free(contextP);
 }
 
@@ -493,6 +495,7 @@ next_step:
 
     registration_step(contextP, tv_sec, timeoutP);
     transaction_step(contextP, tv_sec, timeoutP);
+    coap_cleanup_message_deduplication_step(&contextP->message_dedup, tv_sec, timeoutP);
 
     LOG_ARG_DBG("Final timeoutP: %d", (int)*timeoutP);
 #ifdef LWM2M_CLIENT_MODE

--- a/include/liblwm2m.h
+++ b/include/liblwm2m.h
@@ -823,6 +823,13 @@ typedef int (*lwm2m_bootstrap_callback_t)(lwm2m_context_t *contextP, void *sessi
                                           void *userData);
 #endif
 
+typedef struct _coap_msg_dedup_ {
+    struct _coap_msg_dedup_ *next;
+    uint16_t mid;
+    void *session;
+    time_t timestamp;
+} coap_msg_dedup_t;
+
 struct _lwm2m_context_
 {
 #ifdef LWM2M_CLIENT_MODE
@@ -850,6 +857,7 @@ struct _lwm2m_context_
 #endif
     uint16_t                nextMID;
     lwm2m_transaction_t *   transactionList;
+    coap_msg_dedup_t *message_dedup;
     void *                  userData;
 };
 

--- a/wakaama.cmake
+++ b/wakaama.cmake
@@ -201,7 +201,7 @@ function(target_sources_coap target)
     target_sources(
         ${target}
         PRIVATE ${WAKAAMA_TOP_LEVEL_DIRECTORY}/coap/block.c ${WAKAAMA_TOP_LEVEL_DIRECTORY}/coap/er-coap-13/er-coap-13.c
-                ${WAKAAMA_TOP_LEVEL_DIRECTORY}/coap/transaction.c
+                ${WAKAAMA_TOP_LEVEL_DIRECTORY}/coap/message_dedup.c ${WAKAAMA_TOP_LEVEL_DIRECTORY}/coap/transaction.c
     )
     # We should not (have to) do this!
     target_include_directories(${target} PRIVATE ${WAKAAMA_TOP_LEVEL_DIRECTORY}/coap)


### PR DESCRIPTION
According to rfc7252#section-4.5 duplicate packets must be dropped.