### PR TITLE
Fix: Check memory allocation before memset operation

### DIFF
--- a/core/registration.c
+++ b/core/registration.c
@@ -1658,8 +1658,8 @@ static lwm2m_client_object_t *prv_decodeRegisterPayload(uint8_t *payload, size_t
             if (objectP == NULL)
             {
                 objectP = (lwm2m_client_object_t *)lwm2m_malloc(sizeof(lwm2m_client_object_t));
-                memset(objectP, 0, sizeof(lwm2m_client_object_t));
                 if (objectP == NULL) goto error;
+                memset(objectP, 0, sizeof(lwm2m_client_object_t));
                 objectP->id = id;
                 objList = (lwm2m_client_object_t *)LWM2M_LIST_ADD(objList, objectP);
             }
@@ -1676,8 +1676,8 @@ static lwm2m_client_object_t *prv_decodeRegisterPayload(uint8_t *payload, size_t
                 if (instanceP == NULL)
                 {
                     instanceP = (lwm2m_list_t *)lwm2m_malloc(sizeof(lwm2m_list_t));
-                    memset(instanceP, 0, sizeof(lwm2m_list_t));
                     instanceP->id = instance;
+                    memset(instanceP, 0, sizeof(lwm2m_list_t));
                     objectP->instanceList = LWM2M_LIST_ADD(objectP->instanceList, instanceP);
                 }
             }

--- a/examples/client/common/object_security.c
+++ b/examples/client/common/object_security.c
@@ -214,8 +214,8 @@ static uint8_t prv_security_write(lwm2m_context_t *contextP, uint16_t instanceId
             if (targetP->uri != NULL)
                 lwm2m_free(targetP->uri);
             targetP->uri = (char *)lwm2m_malloc(dataArray[i].value.asBuffer.length + 1);
-            memset(targetP->uri, 0, dataArray[i].value.asBuffer.length + 1);
             if (targetP->uri != NULL) {
+                memset(targetP->uri, 0, dataArray[i].value.asBuffer.length + 1);
                 strncpy(targetP->uri, (char *)dataArray[i].value.asBuffer.buffer, // NOSONAR
                         dataArray[i].value.asBuffer.length);
                 result = COAP_204_CHANGED;
@@ -250,8 +250,8 @@ static uint8_t prv_security_write(lwm2m_context_t *contextP, uint16_t instanceId
             if (targetP->publicIdentity != NULL)
                 lwm2m_free(targetP->publicIdentity);
             targetP->publicIdentity = (char *)lwm2m_malloc(dataArray[i].value.asBuffer.length + 1);
-            memset(targetP->publicIdentity, 0, dataArray[i].value.asBuffer.length + 1);
             if (targetP->publicIdentity != NULL) {
+                memset(targetP->publicIdentity, 0, dataArray[i].value.asBuffer.length + 1);
                 memcpy(targetP->publicIdentity, (char *)dataArray[i].value.asBuffer.buffer,
                        dataArray[i].value.asBuffer.length);
                 targetP->publicIdLen = dataArray[i].value.asBuffer.length;
@@ -265,8 +265,8 @@ static uint8_t prv_security_write(lwm2m_context_t *contextP, uint16_t instanceId
             if (targetP->serverPublicKey != NULL)
                 lwm2m_free(targetP->serverPublicKey);
             targetP->serverPublicKey = (char *)lwm2m_malloc(dataArray[i].value.asBuffer.length + 1);
-            memset(targetP->serverPublicKey, 0, dataArray[i].value.asBuffer.length + 1);
             if (targetP->serverPublicKey != NULL) {
+                memset(targetP->serverPublicKey, 0, dataArray[i].value.asBuffer.length + 1);
                 memcpy(targetP->serverPublicKey, (char *)dataArray[i].value.asBuffer.buffer,
                        dataArray[i].value.asBuffer.length);
                 targetP->serverPublicKeyLen = dataArray[i].value.asBuffer.length;
@@ -280,8 +280,8 @@ static uint8_t prv_security_write(lwm2m_context_t *contextP, uint16_t instanceId
             if (targetP->secretKey != NULL)
                 lwm2m_free(targetP->secretKey);
             targetP->secretKey = (char *)lwm2m_malloc(dataArray[i].value.asBuffer.length + 1);
-            memset(targetP->secretKey, 0, dataArray[i].value.asBuffer.length + 1);
             if (targetP->secretKey != NULL) {
+                memset(targetP->secretKey, 0, dataArray[i].value.asBuffer.length + 1);
                 memcpy(targetP->secretKey, (char *)dataArray[i].value.asBuffer.buffer,
                        dataArray[i].value.asBuffer.length);
                 targetP->secretKeyLen = dataArray[i].value.asBuffer.length;


### PR DESCRIPTION
- Moved the NULL check after memory allocation to occur before the memset call, preventing potential undefined behavior if the allocation fails.
- Ensures safe memory handling and avoids crashes due to dereferencing a NULL pointer.