### PR TITLE
ci: Add action to run `Valgrind` on unit tests

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -1,0 +1,39 @@
+name: Test with Valgrind
+
+on:
+  push:
+    branches: '**'
+  pull_request:
+    branches: '**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-24.04
+
+    strategy:
+      matrix:
+        tool: ["memcheck", "helgrind"]
+
+    steps:
+    - name: Checkout code including full history and submodules
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        submodules: true
+        fetch-depth: 0
+
+    - name: Install dependencies from APT repository
+      run: |
+        sudo apt-get update
+        sudo apt-get install cmake libcunit1-dev ninja-build valgrind
+
+    - name: Build Wakaama
+      run: |
+        tools/ci/run_ci.sh --run-build --valgrind ${{ matrix.tool }}  --verbose
+
+    - name: Execute unit tests with Valgrind
+      run: |
+        tools/ci/run_ci.sh --run-tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,9 +43,25 @@ target_sources_wakaama(${TARGET_NAME})
 
 target_link_libraries(${TARGET_NAME} PRIVATE wakaama_command_line wakaama_platform_posix wakaama_transport_testing_fake)
 
+if(SANITIZER AND WAKAAMA_ENABLE_VALGRIND)
+    message(FATAL_ERROR "Sanitizers are not compatible with Valgrind. Use only one at a time.")
+endif()
+
 if(SANITIZER)
     target_compile_options(${TARGET_NAME} PRIVATE -fsanitize=${SANITIZER} -fno-sanitize-recover=all)
     target_link_options(${TARGET_NAME} PRIVATE -fsanitize=${SANITIZER} -fno-sanitize-recover=all)
+endif()
+
+if(VALGRIND)
+    if(VALGRIND STREQUAL "memcheck")
+        set(VALGRIND_LAUNCHER valgrind --tool=memcheck --leak-check=full --show-leak-kinds=all --track-origins=yes
+                              --error-exitcode=1
+        )
+    elseif(VALGRIND STREQUAL "helgrind")
+        set(VALGRIND_LAUNCHER valgrind --tool=helgrind --error-exitcode=1)
+    else()
+        message(FATAL_ERROR "Valgrind tool '${VALGRIND}' not supported")
+    endif()
 endif()
 
 if(COVERAGE)
@@ -53,5 +69,6 @@ if(COVERAGE)
     target_link_options(${TARGET_NAME} PRIVATE --coverage)
 endif()
 
+get_target_property(TEST_WORKING_DIR ${TARGET_NAME} BINARY_DIR)
 # Add our unit tests to the "test" target
-add_test(NAME ${TARGET_NAME}_test COMMAND ${TARGET_NAME})
+add_test(NAME ${TARGET_NAME}_test COMMAND ${VALGRIND_LAUNCHER} ${TEST_WORKING_DIR}/${TARGET_NAME} COMMAND_EXPAND_LISTS)

--- a/tools/ci/run_ci.sh
+++ b/tools/ci/run_ci.sh
@@ -26,6 +26,7 @@ OPT_C_EXTENSIONS=""
 OPT_C_STANDARD=""
 OPT_CLANG_FORMAT="clang-format-18"
 OPT_SANITIZER=""
+OPT_VALGRIND=""
 OPT_SCAN_BUILD=""
 OPT_SONARQUBE=""
 OPT_SOURCE_DIRECTORY="${REPO_ROOT_DIR}"
@@ -67,6 +68,8 @@ Options:
                             presets are placed into 'build-presets' by default.
   --sanitizer TYPE          Enable sanitizer
                             (TYPE: address leak thread undefined)
+  --valgrind TOOL           Enable valgrind
+                            (TOOL: memcheck helgrind)
   --scan-build BINARY       Enable Clang code analyzer using specified
                             executable
                             (BINARY: e.g. scan-build-10)
@@ -292,6 +295,7 @@ if ! PARSED_OPTS=$($getopt -o vah \
                           -l run-doxygen \
                           -l run-code-checker \
                           -l sanitizer: \
+                          -l valgrind: \
                           -l scan-build: \
                           -l sonarqube: \
                           -l source-directory: \
@@ -370,6 +374,10 @@ while true; do
       OPT_SANITIZER=$2
       shift 2
       ;;
+    --valgrind)
+      OPT_VALGRIND=$2
+      shift 2
+      ;;
     --scan-build)
       OPT_SCAN_BUILD=$2
       # Analyzing works only when code gets actually built
@@ -446,6 +454,10 @@ fi
 
 if [ -n "${OPT_SANITIZER}" ]; then
   CMAKE_ARGS="${CMAKE_ARGS} -DSANITIZER=${OPT_SANITIZER}"
+fi
+
+if [ -n "${OPT_VALGRIND}" ]; then
+  CMAKE_ARGS="${CMAKE_ARGS} -DVALGRIND=${OPT_VALGRIND}"
 fi
 
 if [ -n "${OPT_SCAN_BUILD}" ] && [ -n "${OPT_SONARQUBE}" ]; then


### PR DESCRIPTION
Run the `memcheck` and `helgrind` tools of `Valgrind` as Github actions.