### PR TITLE
utils: Add `strlen` function that can be limited in max. length

### DIFF
--- a/core/management.c
+++ b/core/management.c
@@ -442,7 +442,7 @@ static void prv_resultCallback(lwm2m_context_t * contextP,
                 return;
             }
 
-            result = lwm2m_stringToUri(locationString, strlen(locationString), &locationUri);
+            result = lwm2m_stringToUri(locationString, utils_strlen(locationString), &locationUri);
             if (result == 0)
             {
                 LOG_DBG("Error: lwm2m_stringToUri() failed for Location_path option in prv_resultCallback()");

--- a/core/objects.c
+++ b/core/objects.c
@@ -784,19 +784,19 @@ int object_getRegisterPayloadBufferLength(lwm2m_context_t * contextP)
     uint8_t buffer[REG_OBJECT_MIN_LEN + 5];
 
     LOG_DBG("Entering");
-    index = strlen(REG_START);
+    index = utils_strlen(REG_START);
 
     if ((contextP->altPath != NULL)
      && (contextP->altPath[0] != 0))
     {
-        index += strlen(contextP->altPath);
+        index += utils_strlen(contextP->altPath);
     }
     else
     {
-        index += strlen(REG_DEFAULT_PATH);
+        index += utils_strlen(REG_DEFAULT_PATH);
     }
 
-    index += strlen(REG_LWM2M_RESOURCE_TYPE);
+    index += utils_strlen(REG_LWM2M_RESOURCE_TYPE);
 
     for (objectP = contextP->objectList; objectP != NULL; objectP = objectP->next)
     {
@@ -817,7 +817,7 @@ int object_getRegisterPayloadBufferLength(lwm2m_context_t * contextP)
         if (objectP->versionMajor != 0 || objectP->versionMinor != 0)
         {
             index -= 1;
-            index += strlen(REG_VERSION_START);
+            index += utils_strlen(REG_VERSION_START);
 
             result = utils_uintToText(objectP->versionMajor, buffer, sizeof(buffer));
             if (result < 0) return 0;
@@ -840,7 +840,7 @@ int object_getRegisterPayloadBufferLength(lwm2m_context_t * contextP)
         else if(objectP->instanceList == NULL)
         {
             index -= 1;
-            index += strlen(REG_PATH_END);
+            index += utils_strlen(REG_PATH_END);
         }
 
         if (objectP->instanceList != NULL)
@@ -857,7 +857,7 @@ int object_getRegisterPayloadBufferLength(lwm2m_context_t * contextP)
                 if (result == 0) return 0;
                 index += result;
 
-                index += strlen(REG_PATH_END);
+                index += utils_strlen(REG_PATH_END);
             }
         }
     }

--- a/core/packet.c
+++ b/core/packet.c
@@ -869,7 +869,7 @@ void lwm2m_handle_packet(lwm2m_context_t *contextP, uint8_t *buffer, size_t leng
         }
         /* Reuse input buffer for error message. */
         coap_init_message(message, COAP_TYPE_ACK, coap_error_code, message->mid);
-        coap_set_payload(message, coap_error_message, strlen(coap_error_message));
+        coap_set_payload(message, coap_error_message, utils_strlen(coap_error_message));
         message_send(contextP, message, fromSessionH);
     }
 }

--- a/core/registration.c
+++ b/core/registration.c
@@ -73,35 +73,35 @@ static int prv_getRegistrationQueryLength(lwm2m_context_t * contextP,
     int res;
     uint8_t buffer[21];
 
-    index = strlen(QUERY_STARTER QUERY_VERSION_FULL QUERY_DELIMITER QUERY_NAME);
-    index += strlen(contextP->endpointName);
+    index = utils_strlen(QUERY_STARTER QUERY_VERSION_FULL QUERY_DELIMITER QUERY_NAME);
+    index += utils_strlen(contextP->endpointName);
 
     if (NULL != contextP->msisdn)
     {
-        index += strlen(QUERY_DELIMITER QUERY_SMS);
-        index += strlen(contextP->msisdn);
+        index += utils_strlen(QUERY_DELIMITER QUERY_SMS);
+        index += utils_strlen(contextP->msisdn);
     }
 
 #ifdef LWM2M_VERSION_1_0
     switch (server->binding)
     {
     case BINDING_U:
-        index += strlen("&b=U");
+        index += utils_strlen("&b=U");
         break;
     case BINDING_UQ:
-        index += strlen("&b=UQ");
+        index += utils_strlen("&b=UQ");
         break;
     case BINDING_S:
-        index += strlen("&b=S");
+        index += utils_strlen("&b=S");
         break;
     case BINDING_SQ:
-        index += strlen("&b=SQ");
+        index += utils_strlen("&b=SQ");
         break;
     case BINDING_US:
-        index += strlen("&b=US");
+        index += utils_strlen("&b=US");
         break;
     case BINDING_UQS:
-        index += strlen("&b=UQS");
+        index += utils_strlen("&b=UQS");
         break;
     default:
         return 0;
@@ -135,7 +135,7 @@ static int prv_getRegistrationQueryLength(lwm2m_context_t * contextP,
 
     if (0 != server->lifetime)
     {
-        index += strlen(QUERY_DELIMITER QUERY_LIFETIME);
+        index += utils_strlen(QUERY_DELIMITER QUERY_LIFETIME);
         res = utils_intToText(server->lifetime, buffer, sizeof(buffer));
         if (res == 0) return 0;
         index += res;

--- a/core/utils.c
+++ b/core/utils.c
@@ -210,7 +210,7 @@ size_t utils_intToText(int64_t data,
          */
         if (data == INT64_MIN) {
             const char *const int64_min_str = "-9223372036854775808";
-            const size_t int64_min_strlen = strlen(int64_min_str);
+            const size_t int64_min_strlen = utils_strlen(int64_min_str);
             if (int64_min_strlen >= length) {
                 return 0;
             }
@@ -940,7 +940,7 @@ int utils_stringCopy(char * buffer,
                      size_t length,
                      const char * str)
 {
-    size_t i = strlen(str); // NOSONAR
+    size_t i = utils_strlen(str); // NOSONAR
 
     return (int)utils_strncpy(buffer, length, str, i);
 }
@@ -1157,6 +1157,14 @@ size_t utils_strnlen(const char *str, size_t max_size) {
     }
 
     return pos - str;
+}
+
+size_t utils_strlen(const char *str) {
+#ifdef LWM2M_MAX_STRLEN
+    return utils_strnlen(str, LWM2M_MAX_STRLEN);
+#else
+    return strlen(str); // NOSONAR
+#endif
 }
 
 size_t utils_strncpy(char *dest, const size_t dest_size, const char *src, const size_t src_size) {

--- a/core/utils.h
+++ b/core/utils.h
@@ -68,6 +68,14 @@ lwm2m_client_t *utils_findClient(lwm2m_context_t *contextP, void *fromSessionH);
  */
 size_t utils_strnlen(const char *str, size_t max_size);
 
+/** Same functionality as `strlen`. Finds the number of chars (bytes) of the given string.
+ *
+ * The max. length of checked strings can be limited by setting the define LWM2M_MAX_STRLEN.
+ * @param str The null-terminated string to find the length of.
+ * @return The size of the string.
+ */
+size_t utils_strlen(const char *str);
+
 /** A safer version of `strncpy`. Copies at most src_size bytes to dest, but checks for available space.
  *
  * If dest is not NULL and dest_size is not 0, then the destination buffer is always terminated with '\0'.


### PR DESCRIPTION
The function searches for the terminating `NULL` character in the given string.
It can be configured to search only up to a given maximun length.